### PR TITLE
perf(voxels): retain GPU textures and upload dirty regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,17 @@
 Revision history for CG_Labs
 
+Unreleased
+==========
+
+* Keep voxel textures resident on the GPU and upload only edited slice regions.
+  Unchanged frames and no-op edits perform no voxel transfers.
+* Reject out-of-range voxel coordinates on each axis and release volume-owned
+  GPU resources before the OpenGL context is destroyed.
+  Keep picking valid on all six closed volume faces, including transformed volumes.
+* Regenerate voxel data in contiguous storage order to avoid strided CPU writes.
+* Add a native OpenGL readback smoke check and before/after upload benchmark.
+
+
 
 v2021.2 2021-12-02
 ==================

--- a/CMake/InstallGLM.cmake
+++ b/CMake/InstallGLM.cmake
@@ -30,6 +30,8 @@ if (NOT glm_FOUND)
 		                         -DCMAKE_INSTALL_PREFIX=${glm_INSTALL_DIR}
 		                         -DCMAKE_BUILD_TYPE=Release
 					 -DGLM_TEST_ENABLE=OFF
+		                         -DBUILD_STATIC_LIBS=OFF
+		                         -DBUILD_SHARED_LIBS=OFF
 		                         ${glm_SOURCE_DIR}
 		OUTPUT_VARIABLE stdout
 		ERROR_VARIABLE stderr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,10 @@ include (CMake/InstallTinyFileDialogs.cmake)
 include (CMake/InstallSTB.cmake)
 
 # Resources are found in an external archive
-include (CMake/RetrieveResourceArchive.cmake)
+option (LUGGCGL_DOWNLOAD_RESOURCES "Download the optional course model/texture archive" ON)
+if (LUGGCGL_DOWNLOAD_RESOURCES)
+	include (CMake/RetrieveResourceArchive.cmake)
+endif ()
 
 
 # Configure *C++ Environment Variables*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,46 @@ Paper:
   <img src="https://github.com/theolundqvist/parallax-voxel-ray-marcher/assets/31588188/90c3f8b3-3802-4cdf-89db-8212d5adde82" width=40% height=50%>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/theolundqvist/parallax-voxel-ray-marcher/assets/31588188/b4da6f9a-168f-4347-a2c9-c26bf00fe66e" width=40% height=50%>
 </p>
 
+### Persistent voxel storage
+
+Each volume retains one `GL_R8` 3D texture. The first render uploads the volume;
+unchanged frames upload nothing. Edits track an XY rectangle per Z slice and merge
+matching adjacent slices into `glTexSubImage3D` updates. This uses OpenGL 4.1 APIs,
+including on macOS, without staging copies or changes to the ray-marching shader.
+An update can include unchanged voxels inside its rectangle; it does not upload
+untouched slices. Volume destruction releases the texture and bounding-box buffers.
+Bulk generation visits X-contiguous storage order to keep CPU writes cache-local.
+
+### Reproduce correctness and performance
+
+Use a C++20 compiler and CMake. With Apple Clang 21, provide an installed recent
+Assimp package (the native benchmark used 5.4.3); the bundled 5.1.2 fails to build
+with that compiler. Set `CMAKE_PREFIX_PATH` to its installation prefix if necessary.
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DLUGGCGL_DOWNLOAD_RESOURCES=OFF -DLUGGCGL_BUILD_VOXEL_BENCHMARK=ON
+cmake --build build --target voxel_benchmark --parallel 1
+build/src/EDAN35/voxel_benchmark --strict --output build/voxel
+```
+
+The benchmark uses the real volume implementation and FVTA shader with an offscreen
+1000×1000 framebuffer. macOS uses native CGL; Linux/Windows use GLFW (Linux needs a
+display, or `xvfb-run -a` for software-rendering correctness checks).
+Defaults: 10 warmup frames, 100 measured frames, 100 × 128³ volumes for static,
+spherical boundary edits, and scattered edits; four volumes for full regeneration.
+The terrain is a deterministic sinusoidal heightfield, not the paper's original world.
+
+CSV output separates uploaded bytes/calls, CPU upload time, CPU mutation time, and
+GPU-completed frame time. Texture readbacks are checked and raw RGBA images are saved
+outside timing; `--scenario smoke --strict` checks mutations, no-op updates, bounds, unpack
+state, and texture lifetime. `--isolate-uploads` adds GPU waits around uploads for
+diagnosis only: do not treat those serialized frames as normal frame-rate results.
+For before/after comparisons, use the same harness, dependencies, scene, resolution,
+and arguments on both revisions; omit `--strict` only on the old implementation,
+which does not satisfy the new persistence contract. Report the actual GL renderer:
+software rasterization is not hardware GPU performance.
+
 \
 \
 \

--- a/src/EDAN35/CMakeLists.txt
+++ b/src/EDAN35/CMakeLists.txt
@@ -33,3 +33,14 @@ target_link_libraries (EDAN35_Project PRIVATE assignment_setup)
 install (TARGETS EDAN35_Project DESTINATION bin)
 
 copy_dlls (EDAN35_Project "${CMAKE_CURRENT_BINARY_DIR}")
+
+option (LUGGCGL_BUILD_VOXEL_BENCHMARK "Build the native voxel upload benchmark" OFF)
+if (LUGGCGL_BUILD_VOXEL_BENCHMARK)
+	add_executable (voxel_benchmark benchmark/voxel_benchmark.cpp util/colorPalette.cpp)
+	target_link_libraries (voxel_benchmark PRIVATE assignment_setup)
+	if (APPLE)
+		target_link_libraries (voxel_benchmark PRIVATE "-framework OpenGL")
+	endif ()
+	target_compile_definitions (voxel_benchmark PRIVATE
+		VOXEL_BENCHMARK_SHADER_DIR="${CMAKE_SOURCE_DIR}/shaders/EDAN35")
+endif ()

--- a/src/EDAN35/benchmark/voxel_benchmark.cpp
+++ b/src/EDAN35/benchmark/voxel_benchmark.cpp
@@ -1,0 +1,429 @@
+// Native instrumentation: every intercepted call is forwarded to the real GL driver.
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/norm.hpp>
+#include "core/helpers.hpp"
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/OpenGL.h>
+#include <dlfcn.h>
+#endif
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+#include "EDAN35/util/settings.cpp"
+#include "EDAN35/util/voxel_util.cpp"
+#include "EDAN35/util/IntersectionTests.cpp"
+#include "EDAN35/util/parametric_shapes.cpp"
+#include "EDAN35/project/VoxelVolume.cpp"
+
+namespace {
+using Clock = std::chrono::steady_clock;
+double milliseconds(Clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+}
+void require(bool value, std::string const& message) {
+    if (!value) throw std::runtime_error(message);
+}
+struct Counters {
+    std::uint64_t bytes = 0, image_calls = 0, subimage_calls = 0;
+    double upload_cpu_ms = 0, upload_drained_ms = 0;
+} counters;
+bool isolate_uploads = false;
+int framebuffer_pixels = 1000;
+PFNGLTEXIMAGE3DPROC real_image;
+PFNGLTEXSUBIMAGE3DPROC real_subimage;
+PFNGLDRAWELEMENTSPROC real_draw;
+std::vector<GLubyte> const* expected = nullptr;
+GLuint sampled_texture = 0;
+std::uint64_t texture_hash = 0;
+std::uint64_t hash(std::vector<GLubyte> const& bytes) {
+    std::uint64_t result = 14695981039346656037ull;
+    for (auto value : bytes) result = (result ^ value) * 1099511628211ull;
+    return result;
+}
+void APIENTRY image(GLenum target, GLint level, GLint internal, GLsizei w,
+                    GLsizei h, GLsizei d, GLint border, GLenum format,
+                    GLenum type, void const* data) {
+    if (isolate_uploads) glFinish();
+    auto start = Clock::now();
+    real_image(target, level, internal, w, h, d, border, format, type, data);
+    counters.upload_cpu_ms += milliseconds(start);
+    if (isolate_uploads) { glFinish(); counters.upload_drained_ms += milliseconds(start); }
+    if (data) counters.bytes += std::uint64_t(w) * h * d;
+    ++counters.image_calls;
+}
+void APIENTRY subimage(GLenum target, GLint level, GLint x, GLint y, GLint z,
+                       GLsizei w, GLsizei h, GLsizei d, GLenum format,
+                       GLenum type, void const* data) {
+    if (isolate_uploads) glFinish();
+    auto start = Clock::now();
+    real_subimage(target, level, x, y, z, w, h, d, format, type, data);
+    counters.upload_cpu_ms += milliseconds(start);
+    if (isolate_uploads) { glFinish(); counters.upload_drained_ms += milliseconds(start); }
+    counters.bytes += std::uint64_t(w) * h * d;
+    ++counters.subimage_calls;
+}
+void APIENTRY draw(GLenum mode, GLsizei count, GLenum type, void const* indices) {
+    if (expected) {
+        GLint bound = 0;
+        glGetIntegerv(GL_TEXTURE_BINDING_3D, &bound);
+        sampled_texture = GLuint(bound);
+        std::vector<GLubyte> data(expected->size());
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        glGetTexImage(GL_TEXTURE_3D, 0, GL_RED, GL_UNSIGNED_BYTE, data.data());
+        require(data == *expected, "Real 3D texture readback differs from CPU voxels");
+        texture_hash = hash(data);
+    }
+    real_draw(mode, count, type, indices);
+}
+void checkGL(std::string const& where) {
+    auto error = glGetError();
+    require(error == GL_NO_ERROR, where + ": GL error " + std::to_string(error));
+}
+std::string load(std::string const& path) {
+    std::ifstream stream(path);
+    require(bool(stream), "Cannot read " + path);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+GLuint shader(GLenum type, std::string const& path) {
+    auto source = load(path);
+    auto text = source.c_str();
+    auto object = glCreateShader(type);
+    glShaderSource(object, 1, &text, nullptr);
+    glCompileShader(object);
+    GLint ok = 0;
+    glGetShaderiv(object, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[16384]{};
+        glGetShaderInfoLog(object, sizeof(log), nullptr, log);
+        throw std::runtime_error(path + ": " + log);
+    }
+    return object;
+}
+GLuint program() {
+    auto vs = shader(GL_VERTEX_SHADER, std::string(VOXEL_BENCHMARK_SHADER_DIR) + "/voxel.vert");
+    auto fs = shader(GL_FRAGMENT_SHADER, std::string(VOXEL_BENCHMARK_SHADER_DIR) + "/voxel.frag");
+    auto result = glCreateProgram();
+    glAttachShader(result, vs); glAttachShader(result, fs); glLinkProgram(result);
+    GLint ok = 0;
+    glGetProgramiv(result, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[16384]{};
+        glGetProgramInfoLog(result, sizeof(log), nullptr, log);
+        throw std::runtime_error(std::string("Shader link: ") + log);
+    }
+    glDeleteShader(vs); glDeleteShader(fs);
+    return result;
+}
+struct Surface {
+#ifdef __APPLE__
+    CGLContextObj context = nullptr;
+    void* framework = nullptr;
+#endif
+    GLFWwindow* window = nullptr;
+    GLuint framebuffer = 0, color = 0, depth = 0;
+    Surface() {
+        const int pixels = framebuffer_pixels;
+#ifdef __APPLE__
+        CGLPixelFormatAttribute attributes[] = {kCGLPFAOpenGLProfile,
+            static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_GL4_Core),
+            kCGLPFAAccelerated, kCGLPFAAllowOfflineRenderers,
+            static_cast<CGLPixelFormatAttribute>(0)};
+        CGLPixelFormatObj format = nullptr;
+        GLint count = 0;
+        require(CGLChoosePixelFormat(attributes, &format, &count) == kCGLNoError && format, "CGL pixel format unavailable");
+        auto error = CGLCreateContext(format, nullptr, &context);
+        CGLDestroyPixelFormat(format);
+        require(error == kCGLNoError && context, "CGL context creation failed");
+        require(CGLSetCurrentContext(context) == kCGLNoError, "CGL context activation failed");
+        framework = dlopen("/System/Library/Frameworks/OpenGL.framework/OpenGL", RTLD_LAZY | RTLD_GLOBAL);
+        require(framework != nullptr, "Cannot load native OpenGL framework");
+        require(gladLoadGLLoader([](char const* name) -> void* { return dlsym(RTLD_DEFAULT, name); }) != 0, "GLAD initialization failed");
+#else
+        glfwSetErrorCallback([](int code, char const* text) { std::cerr << "GLFW " << code << ": " << text << '\n'; });
+        require(glfwInit() == GLFW_TRUE, "glfwInit failed");
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        window = glfwCreateWindow(pixels, pixels, "voxel benchmark", nullptr, nullptr);
+        require(window != nullptr, "Cannot create native GL 4.1 core context");
+        glfwMakeContextCurrent(window);
+        glfwSwapInterval(0);
+        require(gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress)) != 0, "GLAD initialization failed");
+#endif
+        glGenFramebuffers(1, &framebuffer); glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+        glGenTextures(1, &color); glBindTexture(GL_TEXTURE_2D, color);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, pixels, pixels, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color, 0);
+        glGenRenderbuffers(1, &depth); glBindRenderbuffer(GL_RENDERBUFFER, depth);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, pixels, pixels);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth);
+        require(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE, "Incomplete framebuffer");
+        glViewport(0, 0, pixels, pixels); glEnable(GL_DEPTH_TEST);
+        glClearColor(0.1f, 0.15f, 0.2f, 1.0f);
+        real_image = glad_glTexImage3D; glad_glTexImage3D = image;
+        real_subimage = glad_glTexSubImage3D; glad_glTexSubImage3D = subimage;
+        real_draw = glad_glDrawElements; glad_glDrawElements = draw;
+        checkGL("context setup");
+    }
+    ~Surface() {
+        glDeleteRenderbuffers(1, &depth); glDeleteTextures(1, &color);
+        glDeleteFramebuffers(1, &framebuffer);
+#ifdef __APPLE__
+        CGLSetCurrentContext(nullptr); CGLDestroyContext(context);
+        dlclose(framework);
+#else
+        glfwDestroyWindow(window); glfwTerminate();
+    #endif
+    }
+};
+std::vector<GLubyte> cpu(VoxelVolume const& volume) {
+    std::vector<GLubyte> result(std::size_t(volume.W) * volume.H * volume.D);
+    for (int z = 0; z < volume.D; ++z)
+        for (int y = 0; y < volume.H; ++y)
+            for (int x = 0; x < volume.W; ++x)
+                result[x + volume.W * (y + volume.H * z)] = GLubyte(volume.getVoxel(x, y, z));
+    return result;
+}
+void render(VoxelVolume& volume, glm::mat4 const& clip, glm::vec3 camera, bool verify = false) {
+    std::vector<GLubyte> data;
+    if (verify) { data = cpu(volume); expected = &data; }
+    volume.render(glm::mat4(1), clip, camera, false, 1, 1);
+    expected = nullptr;
+}
+std::uint64_t saveImage(std::string const& path) {
+    std::vector<GLubyte> image(framebuffer_pixels * framebuffer_pixels * 4);
+    glReadPixels(0, 0, framebuffer_pixels, framebuffer_pixels, GL_RGBA, GL_UNSIGNED_BYTE, image.data());
+    std::ofstream output(path, std::ios::binary);
+    require(bool(output), "Cannot write " + path);
+    output.write(reinterpret_cast<char const*>(image.data()), image.size());
+    return hash(image);
+}
+void smoke(GLuint shader_program, bool strict, std::ostream& log, std::string const& prefix) {
+    glm::vec3 camera(2, 1.7f, 2.5f);
+    auto clip = glm::perspective(glm::radians(40.0f), 1.0f, 0.1f, 20.0f) * glm::lookAt(camera, glm::vec3(0.5f), glm::vec3(0,1,0));
+    auto volume = std::make_unique<VoxelVolume>(17, 9, 5, Transform());
+    volume->setProgram(shader_program);
+    auto verify = [&](char const* stage, bool clean = false) {
+        counters = {};
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        render(*volume, clip, camera, true);
+        glFinish(); checkGL(stage);
+        if (strict && clean) require(counters.bytes == 0 && counters.image_calls == 0 && counters.subimage_calls == 0, std::string(stage) + ": unchanged volume uploaded");
+        log << "smoke," << stage << ",bytes=" << counters.bytes << ",image_calls=" << counters.image_calls << ",subimage_calls=" << counters.subimage_calls << ",texture_hash=" << texture_hash << '\n';
+    };
+    verify("initial");
+    if (strict) require(counters.image_calls == 1 && counters.bytes == 17 * 9 * 5, "Initial upload not exactly once");
+    verify("unchanged", true);
+    volume->setVoxel(0,0,0,13); volume->setVoxel(16,8,4,201);
+    volume->setVoxel(3,7,2,77); volume->setVoxel(15,1,2,88);
+    verify("edge-disjoint");
+    if (strict) require(counters.image_calls == 0 && counters.bytes < 17 * 9 * 5, "Disjoint edits uploaded full volume");
+    volume->setVoxel(3,7,2,77);
+    verify("same-value", true);
+    volume->updateVoxels([](int, int, int, GLubyte previous) { return previous; });
+    verify("callback-noop", true);
+    volume->updateVoxels([&volume](int x,int y,int z,GLubyte previous) {
+        if (x==0 && y==0 && z==0) volume->setVoxel(x,y,z,99);
+        return previous;
+    });
+    require(volume->getVoxel(0,0,0)==13, "Callback return did not replace its reentrant mutation");
+    verify("callback-reentrant");
+    volume->updateVoxels([](int x, int y, int z, GLubyte) { return GLubyte(1 + (x + 3*y + 7*z) % 254); });
+    verify("callback-full");
+    std::vector<std::vector<std::vector<GLubyte>>> imported(17, std::vector<std::vector<GLubyte>>(9, std::vector<GLubyte>(5)));
+    std::vector<std::vector<GLubyte*>> rows(17, std::vector<GLubyte*>(9));
+    std::vector<GLubyte**> planes(17);
+    for (int x=0; x<17; ++x) { planes[x] = rows[x].data(); for (int y=0; y<9; ++y) { rows[x][y] = imported[x][y].data(); for (int z=0; z<5; ++z) imported[x][y][z] = GLubyte(1+(x*11+y*3+z)%254); } }
+    volume->setVolumeData3D(planes.data()); verify("import");
+    volume->setVolumeData3D(planes.data()); verify("import-repeat", true);
+    volume->setSphere(glm::vec3(0.5f), 0.18f, 222); verify("sphere");
+    volume->setSphere(glm::vec3(0.0f,0.4f,0.5f), 0.12f, 111); verify("sphere-boundary-add");
+    volume->setSphere(glm::vec3(0.0f,0.4f,0.5f), 0.12f, 0); verify("sphere-boundary-remove");
+    volume->cleanVoxel(); verify("clear");
+    volume->cleanVoxel(); verify("clear-repeat", true);
+    volume->setVoxel(8,4,2,255); verify("final-visible");
+    auto image_hash = saveImage(prefix + "-smoke.rgba");
+    log << "smoke,image_hash=" << image_hash << '\n';
+    if (strict) {
+        auto before = cpu(*volume);
+        for (auto p : {glm::ivec3(-1,1,1), glm::ivec3(17,0,0), glm::ivec3(0,-1,1), glm::ivec3(0,9,0), glm::ivec3(0,0,-1), glm::ivec3(0,0,5)}) {
+            require(volume->getVoxel(p) == -1, "Invalid per-axis read accepted");
+            require(!volume->setVoxel(p,42), "Invalid per-axis write accepted");
+        }
+        require(before == cpu(*volume), "Invalid coordinates modified voxels");
+        verify("invalid-edits", true);
+        GLuint pbo = 0; glGenBuffers(1,&pbo); glBindBuffer(GL_PIXEL_UNPACK_BUFFER,pbo);
+        glBufferData(GL_PIXEL_UNPACK_BUFFER, 4096, nullptr, GL_STATIC_DRAW);
+        const GLenum keys[] = {GL_UNPACK_ALIGNMENT,GL_UNPACK_ROW_LENGTH,GL_UNPACK_IMAGE_HEIGHT,GL_UNPACK_SKIP_PIXELS,GL_UNPACK_SKIP_ROWS,GL_UNPACK_SKIP_IMAGES};
+        const GLint poison[] = {8,31,23,2,3,1};
+        for (int i=0;i<6;++i) glPixelStorei(keys[i],poison[i]);
+        volume->setVoxel(16,8,4,99); verify("poisoned-unpack");
+        for (int i=0;i<6;++i) { GLint value=0; glGetIntegerv(keys[i],&value); require(value==poison[i], "Unpack state not restored"); }
+        GLint bound=0; glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING,&bound); require(GLuint(bound)==pbo,"Unpack PBO binding not restored");
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER,0); glDeleteBuffers(1,&pbo);
+        for (int i=0;i<6;++i) glPixelStorei(keys[i],i==0 ? 4 : 0);
+        auto texture = sampled_texture;
+        require(glIsTexture(texture)==GL_TRUE,"Volume texture not alive after render");
+        volume.reset();
+        require(glIsTexture(texture)==GL_FALSE,"Volume texture not deleted by destructor");
+        log << "smoke,strict-bounds-unpack-lifetime=pass\n";
+    }
+}
+void raycastSmoke(bool strict, std::ostream& log) {
+    VoxelVolume volume(17,9,5,Transform());
+    bool correct = true;
+    int transformed = 0;
+    for (auto transform : {Transform(),Transform().translate(4,-2,3).rotateAroundY(0.37f).rotateAroundZ(0.23f).scale(glm::vec3(2,0.6f,1.4f))}) {
+        volume.transform = transform;
+        volume.updateVoxels([](int,int,int,GLubyte) { return GLubyte(9); });
+        auto directionToWorld = [&](glm::vec3 direction) {
+            return glm::normalize(glm::vec3(transform.getMatrix()*glm::vec4(direction,0)));
+        };
+        for (int axis=0;axis<3;++axis) for (int side : {-1,1}) {
+            glm::vec3 origin(0.5f), direction(0);
+            origin[axis] = side<0 ? -1.0f : 2.0f;
+            direction[axis] = float(-side);
+            auto wanted = volume.size()/2;
+            wanted[axis] = side<0 ? 0 : volume.size()[axis]-1;
+            auto hit = volume.raycast(transform.apply(origin),directionToWorld(direction));
+            bool valid = !hit.miss && hit.material==9 && hit.index==wanted;
+            correct = correct && valid;
+            log << "raycast,transformed=" << transformed << ",axis=" << axis << ",side=" << side << ",miss=" << hit.miss;
+            if (!hit.miss) log << ",index=" << hit.index.x << ':' << hit.index.y << ':' << hit.index.z;
+            log << ",correct=" << valid << '\n';
+        }
+        auto inside = volume.raycast(transform.apply(glm::vec3(0.5f)),directionToWorld(glm::vec3(1,0,0)));
+        bool inside_ok = !inside.miss && inside.material==9 && inside.index==volume.size()/2;
+        auto away = volume.raycast(transform.apply(glm::vec3(2,0.5f,0.5f)),directionToWorld(glm::vec3(1,0,0)));
+        if (!transformed) {
+            auto closed_corner = volume.isInside(glm::vec3(1));
+            bool closed_ok = !closed_corner.miss && closed_corner.material==9 && closed_corner.index==volume.size()-glm::ivec3(1);
+            log << "raycast,closed_corner_correct=" << closed_ok << '\n';
+            correct = correct && closed_ok;
+        }
+        volume.cleanVoxel();
+        auto empty = volume.raycast(transform.apply(glm::vec3(-1,0.5f,0.5f)),directionToWorld(glm::vec3(1,0,0)));
+        log << "raycast,transformed=" << transformed << ",inside_correct=" << inside_ok << ",away_miss=" << away.miss << ",empty_miss=" << empty.miss << '\n';
+        correct = correct && inside_ok && away.miss && empty.miss;
+        ++transformed;
+    }
+    if (strict) require(correct, "Six-face raycast/editing contract failed");
+}
+
+struct Options {
+    int volumes=100, dynamic_volumes=4, frames=100, warmup=10;
+    bool strict=false;
+    std::string label="candidate", scenario="all", output="voxel-benchmark";
+};
+Options options(int argc, char** argv) {
+    Options result;
+    for (int i=1;i<argc;++i) {
+        std::string arg=argv[i];
+        if (arg=="--strict") { result.strict=true; continue; }
+        if (arg=="--isolate-uploads") { isolate_uploads=true; continue; }
+        require(i+1<argc,"Missing value for "+arg);
+        std::string value=argv[++i];
+        if (arg=="--label") result.label=value;
+        else if (arg=="--scenario") result.scenario=value;
+        else if (arg=="--output") result.output=value;
+        else if (arg=="--volumes") result.volumes=std::stoi(value);
+        else if (arg=="--dynamic-volumes") result.dynamic_volumes=std::stoi(value);
+        else if (arg=="--frames") result.frames=std::stoi(value);
+        else if (arg=="--warmup") result.warmup=std::stoi(value);
+        else if (arg=="--pixels") framebuffer_pixels=std::stoi(value);
+        else throw std::runtime_error("Unknown option "+arg);
+    }
+    require(result.volumes>0 && result.dynamic_volumes>0 && result.frames>0 && result.warmup>=0,"Invalid workload sizes");
+    require(framebuffer_pixels>0 && framebuffer_pixels<=4096,"Invalid framebuffer size");
+    require(result.scenario=="all" || result.scenario=="smoke" || result.scenario=="static" || result.scenario=="local" || result.scenario=="scattered" || result.scenario=="full","Invalid scenario");
+    return result;
+}
+void benchmark(std::string const& scenario, Options const& opts, GLuint shader_program, std::ostream& csv, std::ostream& log) {
+    const int count=scenario=="full" ? opts.dynamic_volumes : opts.volumes;
+    const int side=int(std::ceil(std::sqrt(double(count))));
+    const glm::vec3 center(side*0.5f,0.5f,side*0.5f), camera=center+glm::vec3(side*0.8f,side*0.7f,side*1.1f);
+    const auto clip=glm::perspective(glm::radians(45.0f),1.0f,0.1f,1000.0f)*glm::lookAt(camera,center,glm::vec3(0,1,0));
+    std::vector<std::unique_ptr<VoxelVolume>> volumes;
+    for (int i=0;i<count;++i) {
+        auto volume=std::make_unique<VoxelVolume>(128,128,128,Transform().translate(float(i%side),0,float(i/side)));
+        volume->setProgram(shader_program);
+        volume->setShaderSetting(fvta_step_material);
+        // Continuous sinusoidal heightfield, not the original app's procedural world.
+        volume->updateVoxels([i,side,&scenario](int x,int y,int z,GLubyte) {
+            const auto height=48+24*std::sin((x+128*(i%side))*0.018)*std::cos((z+128*(i/side))*0.020);
+            return GLubyte(scenario!="full" && y>=height ? 0 : 1+(x+3*y+7*z)%254);
+        });
+        volumes.push_back(std::move(volume));
+    }
+    // First allocation is recorded separately, not hidden inside measured frames.
+    counters={}; glFinish(); auto initial=Clock::now();
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+    for (auto& v:volumes) render(*v,clip,camera);
+    glFinish(); checkGL("initial benchmark upload");
+    log << scenario << ",initial_bytes=" << counters.bytes << ",initial_calls=" << counters.image_calls << ",initial_ms=" << milliseconds(initial) << '\n';
+    for (int frame=-opts.warmup;frame<opts.frames;++frame) {
+        const int tick=frame+opts.warmup;
+        glFinish(); counters={}; auto start=Clock::now();
+        for (auto& volume:volumes) {
+            auto& v=*volume;
+            if (scenario=="local") {
+                v.setSphere(v.transform.apply(glm::vec3(0.0f,0.45f,0.5f)),0.025f,tick%2 ? 222 : 0);
+            } else if (scenario=="scattered") {
+                for(int i=0;i<8;++i) v.setVoxel((i&1)?127:0,(i&2)?127:0,i*18,GLubyte(1+tick%254));
+            } else if (scenario=="full") {
+                v.updateVoxels([tick](int x,int y,int z,GLubyte) { return GLubyte(1+(x+3*y+7*z+tick+1)%254); });
+            }
+        }
+        auto mutation_ms=milliseconds(start);
+        auto render_start=Clock::now();
+        glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+        for(auto& volume:volumes) render(*volume,clip,camera);
+        glFinish();
+        auto render_ms=milliseconds(render_start), frame_ms=milliseconds(start);
+        checkGL("benchmark frame");
+        if(opts.strict && scenario=="static") require(counters.bytes==0,"Static frame transferred voxels");
+        if(frame>=0) csv << opts.label << ',' << scenario << ',' << count << ",128,128,128," << frame << ',' << counters.bytes << ',' << counters.image_calls << ',' << counters.subimage_calls << ',' << counters.upload_cpu_ms << ',' << counters.upload_drained_ms << ',' << mutation_ms << ',' << render_ms << ',' << frame_ms << ',' << (isolate_uploads?1:0) << '\n';
+    }
+    // Readbacks are outside timing and cover every volume's actual texture.
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+    for(auto& volume:volumes) { render(*volume,clip,camera,true); log << scenario << ",texture_hash=" << texture_hash << '\n'; }
+    glFinish(); checkGL("benchmark readback");
+    log << scenario << ",image_hash=" << saveImage(opts.output+"-"+scenario+".rgba") << '\n';
+}
+}
+int main(int argc,char** argv) {
+    try {
+        auto opts=options(argc,argv);
+        std::ofstream csv(opts.output+".csv"), log(opts.output+".txt");
+        require(bool(csv)&&bool(log),"Cannot open benchmark output prefix");
+        csv << std::fixed << std::setprecision(6);
+        csv << "label,scenario,volumes,width,height,depth,frame,uploaded_bytes,image_calls,subimage_calls,upload_cpu_ms,upload_drained_ms,mutation_ms,render_finish_ms,whole_frame_ms,isolate_uploads\n";
+        Surface surface;
+        for(auto item:{GL_VENDOR,GL_RENDERER,GL_VERSION,GL_SHADING_LANGUAGE_VERSION}) log << item << '=' << glGetString(item) << '\n';
+        log << "label=" << opts.label << ",warmup=" << opts.warmup << ",frames=" << opts.frames << ",framebuffer=" << framebuffer_pixels << 'x' << framebuffer_pixels << ",shader=fvta_step_material,scene=sinusoidal-heightfield(full:solid),isolate_uploads=" << isolate_uploads << '\n';
+        auto shader_program=program();
+        smoke(shader_program,opts.strict,log,opts.output);
+        raycastSmoke(opts.strict,log);
+        if(opts.scenario!="smoke") for(auto const* scenario:{"static","local","scattered","full"}) if(opts.scenario=="all"||opts.scenario==scenario) benchmark(scenario,opts,shader_program,csv,log);
+        glDeleteProgram(shader_program); checkGL("shutdown");
+        std::cout << "PASS " << opts.output << " (.csv, .txt, .rgba)\n";
+        return 0;
+    } catch(std::exception const& error) { std::cerr << "FAIL: " << error.what() << '\n'; return 1; }
+}

--- a/src/EDAN35/project.cpp
+++ b/src/EDAN35/project.cpp
@@ -22,6 +22,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 
 edan35::Project::Project(WindowManager &windowManager)
         : mCamera(0.5f * glm::half_pi<float>(),
@@ -115,7 +116,7 @@ void edan35::Project::run() {
     // CHANGE HERE FOR DEMOAPP OR REGULAR APP
     // new App...
     // new DemoApp...
-    auto app = new DemoApp(window, &mCamera, &inputHandler, &program_manager, &elapsed_time_ms);
+    auto app = std::make_unique<DemoApp>(window, &mCamera, &inputHandler, &program_manager, &elapsed_time_ms);
 
 
     glClearDepthf(1.0f);

--- a/src/EDAN35/project/App.cpp
+++ b/src/EDAN35/project/App.cpp
@@ -15,10 +15,11 @@
 #include "../util/AppState.cpp"
 #include <map>
 #include <iostream>
+#include <memory>
 
 class App {
 private:
-    VoxelRenderer *renderer;
+    std::unique_ptr<VoxelRenderer> renderer;
     bool showCrosshair = false;
     bool dragToMove = true;
     bool showFps = true;
@@ -66,7 +67,7 @@ public:
         //GameObject::addShaderToLibrary(shaderManager, "fallback", [](GLuint p) {});
         //hitMin->setShader("fallback");
         //hitMax->setShader("fallback");
-        this->renderer = new VoxelRenderer(cam, shaderManager, elapsed_time_ms);
+        this->renderer = std::make_unique<VoxelRenderer>(cam, shaderManager, elapsed_time_ms);
         // create volumes and renderer
         auto tf = Transform().translate(glm::vec3(-1.5)).scale(3.0f);
         //renderer->remove_volumes();

--- a/src/EDAN35/project/DemoApp.cpp
+++ b/src/EDAN35/project/DemoApp.cpp
@@ -16,6 +16,7 @@
 #include "../util/AppState.cpp"
 #include <map>
 #include <iostream>
+#include <memory>
 
 #include "../util/cellularAutomata.hpp"
 
@@ -23,7 +24,7 @@
 
 class DemoApp {
 private:
-    VoxelRenderer *renderer;
+    std::unique_ptr<VoxelRenderer> renderer;
     UI *ui;
     InputHandler *inputHandler;
     GLFWwindow *window;
@@ -65,7 +66,7 @@ public:
         this->elapsed = elapsed_time_ms;
         this->shaderManager = shaderManager;
         ui = new UI(window);
-        this->renderer = new VoxelRenderer(cam, shaderManager, elapsed_time_ms);
+        this->renderer = std::make_unique<VoxelRenderer>(cam, shaderManager, elapsed_time_ms);
 
 
         this->playerBody = new GameObject("playerbody");

--- a/src/EDAN35/project/VoxelVolume.cpp
+++ b/src/EDAN35/project/VoxelVolume.cpp
@@ -5,12 +5,20 @@
 #include "core/opengl.hpp"
 #include <glm/gtx/component_wise.hpp>
 #include "../util/colorPalette.hpp"
+#include <algorithm>
+#include <vector>
 
 
 class VoxelVolume {
 private:
     GLubyte *texels;
     GLuint texture{};
+    struct DirtySlice {
+        int min_x, min_y, max_x, max_y;
+        bool operator==(DirtySlice const &) const = default;
+    };
+    std::vector<DirtySlice> dirty_slices;
+    bool dirty = false;
     bonobo::mesh_data bounding_box;
     IntersectionTests::box_t local_space_AABB = {.min=glm::vec3(0.0), .max=glm::vec3(1.0)};
     std::vector<glm::vec3> colorPalette = colorPalette::generateCAColorPalette(colorPalette::CAColorsBlue2Pink, glm::ivec2(0, 255));
@@ -22,15 +30,14 @@ public:
     Transform transform;
     float voxel_size = 0.1f;
     int LOD = 1;
-    int W;
-    int H;
-    int D;
+    const int W;
+    const int H;
+    const int D;
 
-    VoxelVolume(const int WIDTH, const int HEIGHT, const int DEPTH, Transform tf) {
-        W = WIDTH;
-        H = HEIGHT;
-        D = DEPTH;
+    VoxelVolume(const int WIDTH, const int HEIGHT, const int DEPTH, Transform tf)
+        : W(WIDTH), H(HEIGHT), D(DEPTH) {
         this->transform = tf;
+        dirty_slices.resize(D, {W, H, 0, 0});
 
         voxel_size = 1.0f / (float) W;
 
@@ -39,11 +46,18 @@ public:
         bounding_box = parametric_shapes::createCube(1.0f, 1.0f, 1.0f);
     }
 
+    VoxelVolume(VoxelVolume const &) = delete;
+    VoxelVolume &operator=(VoxelVolume const &) = delete;
+
     void setLOD(int lod) {
         LOD = lod;
     }
 
     ~VoxelVolume() {
+        glDeleteTextures(1, &texture);
+        glDeleteVertexArrays(1, &bounding_box.vao);
+        glDeleteBuffers(1, &bounding_box.bo);
+        glDeleteBuffers(1, &bounding_box.ibo);
         free(texels);
     }
 
@@ -59,8 +73,7 @@ public:
     void setProgram(GLuint shaderProgram) { this->program = shaderProgram; }
 
     int getVoxel(int x, int y, int z) const {
-        int index = x + y * W + z * W * H;
-        if (index >= W * H * D || index < 0) return -1;
+        if (x < 0 || x >= W || y < 0 || y >= H || z < 0 || z >= D) return -1;
         return texels[x + y * W + z * W * H];
     }
 
@@ -69,9 +82,12 @@ public:
     }
 
     bool setVoxel(int x, int y, int z, GLubyte value) {
+        if (x < 0 || x >= W || y < 0 || y >= H || z < 0 || z >= D) return false;
         auto i = x + y * W + z * W * H;
-        if (i < 0 || i >= W * H * D) return false;
-        texels[i] = value;
+        if (texels[i] != value) {
+            texels[i] = value;
+            markDirty(x, y, z);
+        }
         return true;
     }
 
@@ -94,22 +110,25 @@ public:
     }
 
     void updateVoxels(std::function<GLubyte(int x,int y,int z, GLubyte previous)> const get_material){
-        for (int x = 0; x < W; x++) {
+        for (int z = 0; z < D; z++) {
             for (int y = 0; y < H; y++) {
-                for (int z = 0; z < D; z++) {
-                    int prev = texels[x + y * W + z * W * H];
-                    texels[x + y * W + z * W * H] = get_material(x,y,z, prev);
+                for (int x = 0; x < W; x++) {
+                    auto i = x + y * W + z * W * H;
+                    auto value = get_material(x, y, z, texels[i]);
+                    if (texels[i] != value) {
+                        texels[i] = value;
+                        markDirty(x, y, z);
+                    }
                 }
             }
         }
     }
 
     void setVolumeData3D(GLubyte ***data) {
-        texels = (GLubyte *) calloc(W * H * D, sizeof(GLubyte));
         for (int x = 0; x < W; x++) {
             for (int y = 0; y < H; y++) {
                 for (int z = 0; z < D; z++) {
-                    texels[x + y * W + z * W * H] = data[x][y][z];
+                    setVoxel(x, y, z, data[x][y][z]);
                 }
             }
         }
@@ -128,7 +147,7 @@ public:
         if (!IntersectionTests::PointInBox(local_pos, local_space_AABB))
             return {.miss=true};
 
-        auto index = localToIndex(local_pos);
+        auto index = glm::min(localToIndex(local_pos), size() - 1);
         return {
                 .miss=false,
                 .index=index,
@@ -199,21 +218,21 @@ public:
                 //camera inside BB
                 hit.near = local_origin;
             }
-            auto P = transform.apply(hit.near); //world
+            auto local_pos = glm::clamp(hit.near, local_space_AABB.min, local_space_AABB.max);
             float step_size = 1.0 / 10;
             auto step = normalize(w_direction * transform.getScale()) * voxel_size * step_size;
+            auto local_step = inverse.applyRotation(step);
             int i = 0;
             int max_step = (int) (1.0 / step_size * 1.0 / step_size * 1.0 / voxel_size) * 30;
             for (i = 0; i < max_step; ++i) {
-                auto INDEX = localToIndex(inverse.apply(P));
+                if (!IntersectionTests::PointInBox(local_pos, local_space_AABB)) break;
+                // The closed box's maximum faces belong to the last interior voxel.
+                auto INDEX = glm::min(localToIndex(local_pos), size() - 1);
                 auto mat = getVoxel(INDEX);
                 if (mat > 0) {
-                    return {false, INDEX, (GLubyte)mat, this, P};
+                    return {false, INDEX, (GLubyte)mat, this, transform.apply(local_pos)};
                 }
-                else if (mat == -1) {
-                    return {true };
-                }
-                P += step;
+                local_pos += local_step;
             }
         }
         return {.miss = true};
@@ -235,9 +254,6 @@ public:
         // load shader program
         glUseProgram(program);
 
-        // generate texture object
-        glGenTextures(1, &texture);
-
         // Set texture unit for sampler
         glUniform1i(glGetUniformLocation(program, "volume"), 0);
         // Active texture unit before use
@@ -245,16 +261,7 @@ public:
         // Bind 3D texture
         glBindTexture(GL_TEXTURE_3D, texture);
 
-        // setup texture
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        glBindTexture(GL_TEXTURE_3D, texture);
-        glTexImage3D(GL_TEXTURE_3D, 0, GL_RED, W, H, D, 0, GL_RED, GL_UNSIGNED_BYTE,
-                     texels);
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        uploadTexture();
 
 
         // uniforms
@@ -268,7 +275,6 @@ public:
         renderMesh(bounding_box);
 
         // Unbind texture and shader program
-        glDeleteTextures(1, &texture);
         glBindTexture(GL_TEXTURE_3D, 0);
         glUseProgram(0u);
 
@@ -280,6 +286,70 @@ public:
     }
     
 private:
+    void markDirty(int x, int y, int z) {
+        if (texture == 0) return;
+        auto &slice = dirty_slices[z];
+        if (x >= slice.min_x && x < slice.max_x &&
+            y >= slice.min_y && y < slice.max_y) return;
+        slice.min_x = std::min(slice.min_x, x);
+        slice.min_y = std::min(slice.min_y, y);
+        slice.max_x = std::max(slice.max_x, x + 1);
+        slice.max_y = std::max(slice.max_y, y + 1);
+        dirty = true;
+    }
+
+    void uploadTexture() {
+        if (texture != 0 && !dirty) return;
+
+        constexpr GLenum unpack_settings[] = {
+            GL_UNPACK_ALIGNMENT, GL_UNPACK_ROW_LENGTH, GL_UNPACK_IMAGE_HEIGHT,
+            GL_UNPACK_SKIP_PIXELS, GL_UNPACK_SKIP_ROWS, GL_UNPACK_SKIP_IMAGES
+        };
+        GLint previous[6];
+        for (int i = 0; i < 6; ++i) {
+            glGetIntegerv(unpack_settings[i], &previous[i]);
+            glPixelStorei(unpack_settings[i], i == 0 ? 1 : 0);
+        }
+        GLint unpack_buffer;
+        glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &unpack_buffer);
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+        if (texture == 0) {
+            glGenTextures(1, &texture);
+            glBindTexture(GL_TEXTURE_3D, texture);
+            glTexImage3D(GL_TEXTURE_3D, 0, GL_R8, W, H, D, 0, GL_RED,
+                         GL_UNSIGNED_BYTE, texels);
+            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        } else {
+            // Strides address the CPU volume directly, without packing a staging copy.
+            glPixelStorei(GL_UNPACK_ROW_LENGTH, W);
+            glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, H);
+            for (int z = 0; z < D;) {
+                auto const region = dirty_slices[z];
+                if (region.max_x == 0) {
+                    ++z;
+                    continue;
+                }
+                int end_z = z + 1;
+                while (end_z < D && dirty_slices[end_z] == region) ++end_z;
+                glTexSubImage3D(GL_TEXTURE_3D, 0, region.min_x, region.min_y, z,
+                                region.max_x - region.min_x, region.max_y - region.min_y,
+                                end_z - z, GL_RED, GL_UNSIGNED_BYTE,
+                                texels + region.min_x + region.min_y * W + z * W * H);
+                std::fill(dirty_slices.begin() + z, dirty_slices.begin() + end_z,
+                          DirtySlice{W, H, 0, 0});
+                z = end_z;
+            }
+        }
+        dirty = false;
+        for (int i = 0; i < 6; ++i) glPixelStorei(unpack_settings[i], previous[i]);
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, unpack_buffer);
+    }
+
     void setUniforms(glm::mat4 const &tf,
                      glm::mat4 world_to_clip, glm::vec3 cam_pos) const {
         // shader manager

--- a/src/EDAN35/util/noise.cpp
+++ b/src/EDAN35/util/noise.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <vector>
 #include <cstdlib>
+#include <ctime>
 #include <random>
 #include "glm/glm.hpp"
 

--- a/src/EDAN35/util/terrain_generator.cpp
+++ b/src/EDAN35/util/terrain_generator.cpp
@@ -7,7 +7,7 @@ private:
     const int nbr_threads = std::thread::hardware_concurrency() - 1;
     ctpl::thread_pool queue = ctpl::thread_pool(nbr_threads);
     typedef struct result_t {
-        terrain *terrain = nullptr;
+        ::terrain *terrain = nullptr;
         bool retrieved = false;
     } result_t;
     std::vector<result_t> results;


### PR DESCRIPTION
Every draw recreated and uploaded each complete voxel texture, making unchanged worlds pay the same transfer cost as fully regenerated ones.

Keep each texture alive and send only edited slice regions, preserving the existing shader and macOS OpenGL 4.1 compatibility rather than requiring a graphics API rewrite.

Bulk generation now follows contiguous storage order, and picking maps closed volume faces to valid interior voxels so stricter coordinate checks do not break editing.

On Apple M4, static and sparse-edit render frames are 13.65–15.17× faster with byte-identical rendered images; full regeneration improves 3.23× but still transfers every changed voxel.

| Apple M4 workload | Frames per revision | Median frame before (s) | Median frame after (s) | Saved per frame (s) | Speedup |
|---|---:|---:|---:|---:|---:|
| Static terrain, 100 × 128³ volumes | 300 | 0.122969 | 0.008107 | 0.114861 | 15.17× |
| Spherical boundary edits, 100 × 128³ volumes | 300 | 0.121971 | 0.008865 | 0.113106 | 13.76× |
| Scattered edits, 100 × 128³ volumes | 300 | 0.121631 | 0.008908 | 0.112723 | 13.65× |
| Full regeneration, four 128³ volumes | 300 | 0.060258 | 0.018632 | 0.041626 | 3.23× |

[Reproduction commands and measurement boundaries](https://github.com/theolundqvist/parallax-voxel-ray-marcher/blob/4f2fcd8b12fd0fa7a8e7f966651b88c20acef34d/README.md#reproduce-correctness-and-performance)

<details>
<summary>Transfer volume, correctness, and scope</summary>

| Workload | Before per frame | After per frame |
|---|---:|---:|
| Static | 209,715,200 bytes | 0 bytes |
| Spherical edits | 209,715,200 bytes | 12,600 bytes |
| Scattered edits | 209,715,200 bytes | 800 bytes |
| Full regeneration | 8,388,608 bytes | 8,388,608 bytes |

Three paired runs, including reversed order, each used 10 warmup frames and 100 measured frames per workload. Native Apple M4, macOS OpenGL 4.1, 1000×1000 offscreen FVTA rendering of a deterministic sinusoidal heightfield; this is not the paper's original procedural terrain or an M1 retest. Frame time includes CPU mutation and GPU completion, not window presentation, UI, or VSync. The same benchmark harness ran against base f1c907e and head 4f2fcd8; normal measurements did not add per-upload GPU waits.

All 912 compared GPU volume hashes and all 12 scenario framebuffer pairs plus three smoke framebuffer pairs match. Strict checks cover no-op and bulk updates, rectangular volumes, disjoint edits, unpack state and PBO restoration, resource destruction, reentrant callbacks, and picking all six faces of translated, rotated, nonuniformly scaled volumes. The actual application built, rendered, accepted keyboard carving in the quad and cube scenes, and exited normally on Linux.

Linux llvmpipe is software rendering, not additional hardware GPU evidence: its final 100-frame comparisons improve 1.46× static, 1.24× spherical edits, 1.26× scattered edits, and 1.52× full regeneration. A separately controlled single-thread full-regeneration comparison confirms CPU mutation improves from 0.046268 to 0.028542 seconds.

Dirty rectangles may include unchanged voxels between edits within a slice. Unchanged slices are skipped, and fully regenerated data still requires a full transfer. Resident textures intentionally retain GPU memory until their volumes are destroyed. No CI checks were present for this head when inspected; the claims above come from executed native checks and measurements, not a green CI badge.

</details>

![retained-voxel-current-head.png](https://github.com/user-attachments/assets/1a888974-00a4-42ef-97b4-89a7bee7fd2b)
